### PR TITLE
Apptainer installation in conda environment

### DIFF
--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -31,10 +31,10 @@ jobs:
             miniforge-version: latest
             activate-environment: model-validation 
             use-mamba: true
-      - name: Setup Apptainer
-        uses: eWaterCycle/setup-apptainer@v2
-        with:
-          apptainer-version: 1.4.5
+      # - name: Setup Apptainer
+      #   uses: eWaterCycle/setup-apptainer@v2
+      #   with:
+      #     apptainer-version: 1.4.5
       - name: Set strict channel priority
         run: conda config --set channel_priority strict
         

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -31,6 +31,9 @@ jobs:
             miniforge-version: latest
             activate-environment: model-validation 
             use-mamba: true
+      - name: Install fuse2fs
+        run: sudo apt-get update && sudo apt-get install -y fuse2fs
+      
       # - name: Setup Apptainer
       #   uses: eWaterCycle/setup-apptainer@v2
       #   with:

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -43,7 +43,8 @@ jobs:
         
       - name: Update environment
         run: mamba env update -n model-validation -f environment_benchmarks.yml
-
+      - name: namespaces tests
+        run: unshare -U -r sh -c 'echo "inside:"; id; echo "can mount ns?"; unshare -m true && echo yes || echo no'
       - name: generate-config-files
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -31,6 +31,13 @@ jobs:
         shell: bash -l {0}
         run: |
           apptainer build "$APPTAINER_SIF_FILE" docker://julia:1.12.2-bookworm
+      
+      - name: Upload SIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: julia-sif
+          path: ${{ env.APPTAINER_SIF_FILE }}
+          retention-days: 1
 
 
   tests:
@@ -42,7 +49,16 @@ jobs:
     steps:
       - name: checkout repo content
         uses: actions/checkout@v2
+      - name: Download SIF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: julia-sif
+          path: ${{ github.workspace }}/benchmarks/linear-elastic-plate-with-hole
 
+      - name: Verify SIF exists
+        run: |
+          ls -lh "${{ github.workspace }}/benchmarks/linear-elastic-plate-with-hole/julia.sif"
+      
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -74,4 +74,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/benchmarks/linear-elastic-plate-with-hole/
-          snakemake --use-conda --use-apptainer --cores=all --config tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]
+          snakemake --use-conda --use-apptainer --cores=all --config container="APPTAINER_SIF_FILE" tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -74,4 +74,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/benchmarks/linear-elastic-plate-with-hole/
-          snakemake --use-conda --use-apptainer --cores=all --config container="APPTAINER_SIF_FILE" tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]
+          snakemake --use-conda --use-apptainer --cores=all --config container=APPTAINER_SIF_FILE tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -35,6 +35,7 @@ jobs:
 
 
   tests:
+    needs: build-sif
     runs-on: ubuntu-latest
 
 
@@ -61,8 +62,8 @@ jobs:
         
       - name: Update environment
         run: mamba env update -n model-validation -f environment_benchmarks.yml
-      - name: namespaces tests
-        run: unshare -U -r sh -c 'echo "inside:"; id; echo "can mount ns?"; unshare -m true && echo yes || echo no'
+      # - name: namespaces tests
+      #   run: unshare -U -r sh -c 'echo "inside:"; id; echo "can mount ns?"; unshare -m true && echo yes || echo no'
       - name: generate-config-files
         shell: bash -l {0}
         run: |

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -11,10 +11,9 @@ on:
   # Runs the workflow once per day at 3:15am
   schedule:
     - cron: '3 16 * * *'
-
 env:
-  CACHE_NUMBER: 1  # increase to reset cache manually
-  APPTAINER_SIF_FILE: $GITHUB_WORKSPACE/benchmarks/linear-elastic-plate-with-hole/julia.sif
+  CACHE_NUMBER: 1
+  APPTAINER_SIF_FILE: ${{ github.workspace }}/benchmarks/linear-elastic-plate-with-hole/julia.sif
 
 jobs:
   build-sif:
@@ -31,7 +30,7 @@ jobs:
       - name: build sif
         shell: bash -l {0}
         run: |
-          apptainer build APPTAINER_SIF_FILE docker://julia:1.12.2-bookworm
+          apptainer build "$APPTAINER_SIF_FILE" docker://julia:1.12.2-bookworm
 
 
   tests:
@@ -74,4 +73,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd $GITHUB_WORKSPACE/benchmarks/linear-elastic-plate-with-hole/
-          snakemake --use-conda --use-apptainer --cores=all --config container=APPTAINER_SIF_FILE tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]
+          snakemake --use-conda --use-apptainer --cores=all --config container="$APPTAINER_SIF_FILE" tools=[extendablefem] configurations=["1","05","025","0125","00625","003125"]

--- a/.github/workflows/run-julia-benchmark.yml
+++ b/.github/workflows/run-julia-benchmark.yml
@@ -14,8 +14,26 @@ on:
 
 env:
   CACHE_NUMBER: 1  # increase to reset cache manually
+  APPTAINER_SIF_FILE: $GITHUB_WORKSPACE/benchmarks/linear-elastic-plate-with-hole/julia.sif
 
 jobs:
+  build-sif:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v2
+      
+      - name: Setup Apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.4.5
+      - name: build sif
+        shell: bash -l {0}
+        run: |
+          apptainer build APPTAINER_SIF_FILE docker://julia:1.12.2-bookworm
+
+
   tests:
     runs-on: ubuntu-latest
 
@@ -31,8 +49,8 @@ jobs:
             miniforge-version: latest
             activate-environment: model-validation 
             use-mamba: true
-      - name: Install fuse2fs
-        run: sudo apt-get update && sudo apt-get install -y fuse2fs
+      # - name: Install fuse2fs
+      #   run: sudo apt-get update && sudo apt-get install -y fuse2fs
       
       # - name: Setup Apptainer
       #   uses: eWaterCycle/setup-apptainer@v2

--- a/benchmarks/linear-elastic-plate-with-hole/Snakefile
+++ b/benchmarks/linear-elastic-plate-with-hole/Snakefile
@@ -8,6 +8,8 @@ tools = config["tools"]
 benchmark = config["benchmark"]
 benchmark_uri = config["benchmark_uri"]
 
+container_sif = config["container"]
+
 
 rule all:
     input:

--- a/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
+++ b/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
@@ -10,7 +10,7 @@ configurations = config["configurations"]
 rule setup_julia_environment:
     input: f"{tool}/Project.toml"
     output: manifest=f"{tool}/Manifest.toml"
-    container: "docker://julia:1.12.2-bookworm"
+    singularity: "docker://julia:1.12.2-bookworm"
     shell: 
         """
         julia --project={tool} -e 'using Pkg;Pkg.instantiate()'
@@ -24,7 +24,7 @@ rule run_extendablefem_simulation:
     output:
         zip = f"{result_dir}/{{tool}}/solution_field_data_{{configuration}}.zip",
         metrics = f"{result_dir}/{{tool}}/solution_metrics_{{configuration}}.json",
-    container: "docker://julia:1.12.2-bookworm"
+    singularity: "docker://julia:1.12.2-bookworm"
     shell:
         """
         julia --project={tool} {tool}/run_extendablefem_simulation.jl --configfile {input.parameters} --meshfile {input.mesh} --outputzip {output.zip} --outputmetrics {output.metrics}

--- a/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
+++ b/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
@@ -10,7 +10,7 @@ configurations = config["configurations"]
 rule setup_julia_environment:
     input: f"{tool}/Project.toml"
     output: manifest=f"{tool}/Manifest.toml"
-    singularity: "docker://julia:1.12.2-bookworm"
+    container: "docker://julia:1.12.2-bookworm"
     shell: 
         """
         julia --project={tool} -e 'using Pkg;Pkg.instantiate()'
@@ -24,7 +24,7 @@ rule run_extendablefem_simulation:
     output:
         zip = f"{result_dir}/{{tool}}/solution_field_data_{{configuration}}.zip",
         metrics = f"{result_dir}/{{tool}}/solution_metrics_{{configuration}}.json",
-    singularity: "docker://julia:1.12.2-bookworm"
+    container: "docker://julia:1.12.2-bookworm"
     shell:
         """
         julia --project={tool} {tool}/run_extendablefem_simulation.jl --configfile {input.parameters} --meshfile {input.mesh} --outputzip {output.zip} --outputmetrics {output.metrics}

--- a/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
+++ b/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
@@ -7,10 +7,12 @@ result_dir = "snakemake_results/" + config["benchmark"]
 configuration_to_parameter_file = config["configuration_to_parameter_file"]
 configurations = config["configurations"]
 
+container_sif = config["container"]
+
 rule setup_julia_environment:
     input: f"{tool}/Project.toml"
     output: manifest=f"{tool}/Manifest.toml"
-    singularity: f"{tool}/julia.sif"
+    singularity: f"{container_sif}"
     shell: 
         """
         julia --project={tool} -e 'using Pkg;Pkg.instantiate()'
@@ -24,7 +26,7 @@ rule run_extendablefem_simulation:
     output:
         zip = f"{result_dir}/{{tool}}/solution_field_data_{{configuration}}.zip",
         metrics = f"{result_dir}/{{tool}}/solution_metrics_{{configuration}}.json",
-    singularity: f"{tool}/julia.sif"
+    singularity: f"{container_sif}"
     shell:
         """
         julia --project={tool} {tool}/run_extendablefem_simulation.jl --configfile {input.parameters} --meshfile {input.mesh} --outputzip {output.zip} --outputmetrics {output.metrics}

--- a/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
+++ b/benchmarks/linear-elastic-plate-with-hole/extendablefem/Snakefile
@@ -10,7 +10,7 @@ configurations = config["configurations"]
 rule setup_julia_environment:
     input: f"{tool}/Project.toml"
     output: manifest=f"{tool}/Manifest.toml"
-    singularity: "docker://julia:1.12.2-bookworm"
+    singularity: f"{tool}/julia.sif"
     shell: 
         """
         julia --project={tool} -e 'using Pkg;Pkg.instantiate()'
@@ -24,7 +24,7 @@ rule run_extendablefem_simulation:
     output:
         zip = f"{result_dir}/{{tool}}/solution_field_data_{{configuration}}.zip",
         metrics = f"{result_dir}/{{tool}}/solution_metrics_{{configuration}}.json",
-    singularity: "docker://julia:1.12.2-bookworm"
+    singularity: f"{tool}/julia.sif"
     shell:
         """
         julia --project={tool} {tool}/run_extendablefem_simulation.jl --configfile {input.parameters} --meshfile {input.mesh} --outputzip {output.zip} --outputmetrics {output.metrics}

--- a/environment_benchmarks.yml
+++ b/environment_benchmarks.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - snakemake
   - nextflow
+  - apptainer
   - pyvista
   - meshio
   - conda-lock


### PR DESCRIPTION
Installation of apptainer now via the benchmark environment that also contains snakemake. No system-wide installation is needed anymore. Further, replace `singularity` in the snakefile with `container` because the name singularity is not used by the apptainer project anymore