### PR TITLE
Update to reporter plugin version 1.2.6

### DIFF
--- a/environment_benchmarks.yml
+++ b/environment_benchmarks.yml
@@ -11,4 +11,4 @@ dependencies:
   - conda
   - pip
   - pip:
-      - "git+https://github.com/izus-fokus/snakemake-report-plugin-metadata4ing@v1.2.5#egg=snakemake-report-plugin-metadata4ing"
+      - "git+https://github.com/izus-fokus/snakemake-report-plugin-metadata4ing@v1.2.6#egg=snakemake-report-plugin-metadata4ing"


### PR DESCRIPTION
Update to reporter plugin version 1.2.6 to address the Issue #73. We need to explicitly specify the RoCrate version (in our case 1.1). For some unknown reasons, RoCrate version 1.2 fails on validation on CI and will be inspected later. 