### PR TITLE
Update RoHub SPARQL URL

### DIFF
--- a/benchmarks/common/upload_provenance.py
+++ b/benchmarks/common/upload_provenance.py
@@ -109,7 +109,7 @@ def run(args):
         rohub.settings.KEYCLOAK_CLIENT_SECRET = "714617a7-87bc-4a88-8682-5f9c2f60337d"
         rohub.settings.KEYCLOAK_URL = "https://keycloak-dev.apps.paas-dev.psnc.pl/auth/realms/rohub/protocol/openid-connect/token"
         rohub.settings.SPARQL_ENDPOINT = (
-            "https://rohub2020-api-virtuoso-route-rohub.apps.paas-dev.psnc.pl/sparql/"
+            "https://virtuoso-rohub2020-devel.apps.bst2.paas.psnc.pl/sparql"
         )
 
     # Authenticate with RoHub

--- a/benchmarks/notebooks/RoCrate.ipynb
+++ b/benchmarks/notebooks/RoCrate.ipynb
@@ -44,7 +44,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -53,12 +53,12 @@
         "    rohub.settings.KEYCLOAK_CLIENT_ID = \"rohub2020-cli\"\n",
         "    rohub.settings.KEYCLOAK_CLIENT_SECRET = \"714617a7-87bc-4a88-8682-5f9c2f60337d\"\n",
         "    rohub.settings.KEYCLOAK_URL = \"https://keycloak-dev.apps.paas-dev.psnc.pl/auth/realms/rohub/protocol/openid-connect/token\"\n",
-        "    rohub.settings.SPARQL_ENDPOINT = \"https://rohub2020-api-virtuoso-route-rohub.apps.paas-dev.psnc.pl/sparql/\"\n",
+        "    rohub.settings.SPARQL_ENDPOINT = \"https://virtuoso-rohub2020-devel.apps.bst2.paas.psnc.pl/sparql\"\n",
         "else:\n",
         "    rohub.settings.API_URL = \"https://api.rohub.org/api/\"\n",
         "    rohub.settings.KEYCLOAK_CLIENT_ID = \"rohub2020-public-cli\"\n",
         "    rohub.settings.KEYCLOAK_URL = \"https://login.rohub.org/auth/realms/rohub/protocol/openid-connect/token\"\n",
-        "    rohub.settings.SPARQL_ENDPOINT = \"https://rohub2020-api-virtuoso-route-rohub2020.apps.paas.psnc.pl/sparql\""
+        "    rohub.settings.SPARQL_ENDPOINT = \"https://virtuoso-rohub2020-production.apps.bst2.paas.psnc.pl/sparql\""
       ]
     },
     {

--- a/docs/rohub.md
+++ b/docs/rohub.md
@@ -106,7 +106,7 @@ After successfully uploading or creating a research object, api gives back its `
 
 ## Accessing Research Objects
 
-You can access research objects via code (API) or SPARQL endpoint. There are two endpoints, [Production](https://rohub2020-api-virtuoso-route-rohub2020.apps.paas.psnc.pl/sparql) and [Development](https://rohub2020-api-virtuoso-route-rohub.apps.paas-dev.psnc.pl/sparql/%22).
+You can access research objects via code (API) or SPARQL endpoint. There are two endpoints, [Production](https://virtuoso-rohub2020-production.apps.bst2.paas.psnc.pl/sparql) and [Development](https://virtuoso-rohub2020-devel.apps.bst2.paas.psnc.pl/sparql%22).
 
 You can query object properties by id as:
 
@@ -197,7 +197,7 @@ WHERE {
 It is possible upload the snakemake research object artificated which was created by snakemake-metadat4ing-reporter-plugin onto the Rohub, and query the workflow input and output parameters.
 
 After uploading the artifact, the api gives back an id, in our case suppose that it is 
-`a1485323-9904-438d-b188-794a71e58ea3`. We can run the following query on the [Development](https://rohub2020-api-virtuoso-route-rohub.apps.paas-dev.psnc.pl/sparql/%22), and see the results:
+`a1485323-9904-438d-b188-794a71e58ea3`. We can run the following query on the [Development](https://virtuoso-rohub2020-devel.apps.bst2.paas.psnc.pl/sparql%22), and see the results:
 
 ```sparql
 PREFIX schema: <http://schema.org/>


### PR DESCRIPTION
RoHub changed its SPARQL endpoints recently:

Production SPARQL: https://virtuoso-rohub2020-production.apps.bst2.paas.psnc.pl/sparql
Development SPARQL: https://virtuoso-rohub2020-devel.apps.bst2.paas.psnc.pl/sparql 

This PR includes the changes, both in code and documentation.

